### PR TITLE
Using store actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,16 @@ Bind custom socket.io-client instance
 Vue.use(VueSocketio, socketio('http://socketserver.com:1923'));
 ```
 
-Enable Vuex integration
+Enable Vuex integration (use mutations)
 ``` js
 import store from './yourstore'
 Vue.use(VueSocketio, socketio('http://socketserver.com:1923'), store);
+```
+
+Enable Vuex integration (use actoins)
+``` js
+import store from './yourstore'
+Vue.use(VueSocketio, socketio('http://socketserver.com:1923'), store, true);
 ```
 
 #### On Vuejs instance usage
@@ -90,6 +96,51 @@ export default new Vuex.Store({
         otherAction: ({ commit, dispatch, state }, type) => {
             return true;
         }
+    }
+})
+```
+
+Example store, socket actions always have "socket" prefix
+``` js
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+const someModule = {
+  // ...
+  mutations: {
+    SOME_MUTATION: (state, payload) => {
+      // do something
+    }
+  }
+}
+
+const socketModule = {
+  state: {
+        connect: false,
+        message: null
+    },
+    mutations:{
+        CONNECT: (state,  status ) => {
+            state.connect = true;
+        },
+        USER_MESSAGE: (state,  message) => {
+            state.message = message;
+        }
+    },
+    actions: {
+        socketUserMessage: ({ commit, dispatch, state }, message) => {
+            commit(USER_MESSAGE, message);
+            commit(SOME_MUTATION, message);
+        }
+    }
+}
+
+Vue.use(Vuex);
+
+export default new Vuex.Store({
+    modules: {
+      someModule,
+      socketModule
     }
 })
 ```

--- a/src/Main.js
+++ b/src/Main.js
@@ -3,11 +3,11 @@ import Emitter from './Emitter'
 
 export default {
 
-    install(Vue, connection, store){
+    install(Vue, connection, store, useActions = false){
 
         if(!connection) throw new Error("[Vue-Socket.io] cannot locate connection")
 
-        let observer = new Observer(connection, store)
+        let observer = new Observer(connection, store, useActions)
 
         Vue.prototype.$socket = observer.Socket;
 


### PR DESCRIPTION
Store actions allow to use more complicated logic, than mutations. For example, use mutations from other modules, send [bus events](https://vuejs.org/v2/guide/components.html#Non-Parent-Child-Communication) or composing actions.