### PR TITLE
Fix: propagate event to Socket

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -18,7 +18,10 @@ export default class{
     }
 
     onEvent(){
+        var super_onevent = this.Socket.onevent;
         this.Socket.onevent = (packet) => {
+            super_onevent.call(this.Socket, packet);
+
             Emitter.emit(packet.data[0], packet.data[1]);
 
             if(this.store) this.passToStore('SOCKET_'+packet.data[0],  [ ...packet.data.slice(1)])


### PR DESCRIPTION
When a custom socket is passed, its `onevent` method is overriden and it do not receive events anymore.

For example:
```js
import Vue from 'vue'
import VueSocketio from 'vue-socket.io'

var sharedSocket = io();

Vue.use(VueSocketio, sharedSocket);

// ... Out of the Vue app

sharedSocket.on('connect', () => {
    // Never called
});
```

Suggested fix: call `Socket.onevent`.