### PR TITLE
Added namespaced mutations and actions support for vuex Socket listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,39 @@ export default new Vuex.Store({
     }
 })
 ```
+In case of namespaced Vuex module, your code should look like this :
+
+*File : module.js*
+``` js
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex);
+
+export default new Vuex.Store({
+    namespaced: true,
+    state: {
+        action: 0,
+        message: null
+    },
+    mutations:{
+        SOCKET_MESSAGE: (state,  message) => {
+            state.message = message;
+            // This code will fire if an event named 'module/message' is received
+        }
+    },
+    actions: {
+        otherAction: (context, type) => {
+            return true;
+        }
+        socket_actionListener: (state) => {
+            console.log('Received module/actionListener event !!!');
+            state.action ++;
+            // This code will fire if an event named 'module/actionListener' is received
+        }
+    }
+})
+```
 
 ## Example
 [Realtime Car Tracker System](http://metinseylan.com/)

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -43,7 +43,7 @@ export default class{
         if(!event.startsWith('SOCKET_')) return
 
         for(let namespaced in this.store._mutations) {
-            let mutation = namespaced.split('/').pop()
+            let mutation = ('SOCKET_' + namespaced.replace('SOCKET_','')).toUpperCase();
             if(mutation === event.toUpperCase()) this.store.commit(namespaced, payload)
         }
 


### PR DESCRIPTION
I just edited some lines of Observer.js to enable namespaced vuex mutations and actions support. Actions and mutations must be named as explained in the doc, and socket events should be in this format : 

`<module_name>/<action_or_mutation_name>`

I've tested these improvements on a personnal project, and it works.

You can also now use '/' character in your vuex mutations and actions listening Socket.io events.