### PR TITLE
Added multi socket support

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -35,6 +35,31 @@ export default {
                     }
                 })
 
+                this.$options.multisockets = new Proxy({}, {
+                  deleteProperty: (target, key) => {
+                    Object.keys(this.$options.multisockets[key]).forEach(item  => {
+                      Emitter.removeListener(item, this.$options.multisockets[key][item], this)
+                    })
+                    delete target.key;
+                    return true
+                  }
+                })
+
+                Object.keys(connection).forEach(object => {
+                    this.$options.multisockets[object] = new Proxy({}, {
+                      set: (target, key, value) => {
+                        Emitter.addListener(key, value, this)
+                        target[key] = value
+                        return true;
+                      },
+                      deleteProperty: (target, key) => {
+                        Emitter.removeListener(key, this.$options.multisockets[object][key], this)
+                        delete target.key;
+                        return true
+                      }
+                    })
+                })
+
                 if(sockets){
                     Object.keys(sockets).forEach((key) => {
                         this.$options.sockets[key] = sockets[key];

--- a/src/Main.js
+++ b/src/Main.js
@@ -9,7 +9,14 @@ export default {
 
         let observer = new Observer(connection, store)
 
-        Vue.prototype.$socket = observer.Socket;
+        if(typeof connection == 'object'){
+          Vue.prototype.$socket = []
+          Object.keys(connection).forEach(key => {
+            Vue.prototype.$socket[key] = observer.Sockets[key];
+          })
+        }else{
+          Vue.prototype.$socket = observer.Socket;
+        }
 
         Vue.mixin({
             created(){

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -31,6 +31,7 @@ export default class{
 
     onEventWithKey(socket, key){
       var super_onevent = socket.onevent;
+      console.log('super event', super_onevent)
       socket.onevent = (packet) => {
         super_onevent.call(socket, packet);
 

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -4,17 +4,69 @@ import Socket from 'socket.io-client'
 export default class{
 
     constructor(connection, store) {
+      this.Sockets = null
 
-        if(typeof connection == 'string'){
-            this.Socket = Socket(connection);
-        }else{
-            this.Socket = connection
-        }
+      if(typeof connection == 'string'){
+          this.Socket = Socket(connection);
+      } else if(typeof connection == 'object') {
+        this.Sockets = []
+        Object.keys(connection).forEach(key => {
+          this.Sockets[key] = Socket(connection[key]);
+        });
+      } else{
+          this.Socket = connection
+      }
 
-        if(store) this.store = store;
+      if(store) this.store = store;
 
-        this.onEvent()
+      (this.Sockets) ? this.onEvents() : this.onEvent()
+    }
 
+
+    onEvents(){
+      for(let socket in this.Sockets){
+        this.onEventWithKey(this.Sockets[socket], socket)
+      }
+    }
+
+    onEventWithKey(socket, key){
+      var super_onevent = socket.onevent;
+      socket.onevent = (packet) => {
+        super_onevent.call(socket, packet);
+
+        Emitter.emit(packet.data[0], packet.data[1]);
+
+        if(this.store) this.passToStoreWithKey(key.toUpperCase()+'_SOCKET_'+packet.data[0],  [ ...packet.data.slice(1)], key)
+      };
+
+      let _this = this;
+
+      ["connect", "error", "disconnect", "reconnect", "reconnect_attempt", "reconnecting", "reconnect_error", "reconnect_failed", "connect_error", "connect_timeout", "connecting", "ping", "pong"]
+        .forEach((value) => {
+          socket.on(value, (data) => {
+            Emitter.emit(value, data);
+            if(_this.store) _this.passToStoreWithKey(key.toUpperCase()+'_SOCKET_'+value, data, key)
+          })
+        })
+    }
+
+    passToStoreWithKey(event, payload, key){
+      if(!event.startsWith(key.toUpperCase()+'_SOCKET_')) return
+      for(let namespaced in this.store._mutations) {
+        let mutation = namespaced.split('/').pop()
+        if(mutation === event.toUpperCase()) this.store.commit(namespaced, payload)
+      }
+
+      for(let namespaced in this.store._actions) {
+        let action = namespaced.split('/').pop()
+        if(!action.startsWith(key+'_socket_')) continue
+
+        let camelcased = key+'_socket_'+event
+            .replace(key.toUpperCase()+'_SOCKET_', '')
+            .replace(/^([A-Z])|[\W\s_]+(\w)/g, (match, p1, p2) => p2 ? p2.toUpperCase() : p1.toLowerCase())
+
+        if(action === camelcased) this.store.dispatch(namespaced, payload)
+      }
     }
 
     onEvent(){


### PR DESCRIPTION
Added multi socket support. Will be updating README in a while. 

However, here is quick summary:
## Adding multiple namespaces/socket connetions
```js
let connectObj = {
  notification: 'http://localhost:5000/notification',
  client: 'http://localhost:5000/client'
}
Vue.use(VueSocketio, connectObj, store)
```
This adds capability to listen to multiple socket instances (for ex- namespaces) in single Vue instance.
If connection is passed as an object, the keys can be used to identify and thus will be able to isolate listeners. 

## Using Vuex for listening socket events
This is achieved by prefixing object keys to the `SOCKET` prefix that we already have.

Taking above example, `notification` and `client` are **keys** to identify connection. As such, you can now mention in Vuex by prefixing those keys to SOCKET_ to mutations or actions (pardon my english). For ex- 

### Using mutations
```js
mutations: {
   //on notification namespace 
    notification_socket_connect (state) {
      ...
    },

   //Event on client namespace 
    client_socket_connect (state) {
      ...
    }
  }
```

### Using actions
```js
actions: {
    // Listenening on notification namespace 
    notification_socket_someevent (context) {
      ...
    },

    // Listenening on client namespace 
    client_socket_someevent (context) {
      ...
    }
```
## Dynamic socket event listeners

Create a new listener for particular namespace
```js
// Event in notification namespace
this.$options.multisockets.notification.some_event = (data) => { console.log(data) }

// Event in client namespace
this.$options.multisockets.client.some_event = (data) => { console.log(data) }
```

Delete complete namespace listenener or particular event listener
```js
// Will remove every event listener in the notification namespace
 delete this.$options.multisockets.notification
 delete this.$options.multisockets.client

// Or delete particular event from namespace
 delete this.$options.multisockets.notification.some_event
 delete this.$options.multisockets.client.some_event
```

Of course, you can still use your old way of connection. This just extends the capability for namespacing