### PR TITLE
don't dispatch ping to store

### DIFF
--- a/src/emitter.js
+++ b/src/emitter.js
@@ -77,7 +77,9 @@ export default class EventEmitter{
 
         }
 
-        this.dispatchStore(event, args);
+        if(event !== 'ping' && event !== 'pong') {
+            this.dispatchStore(event, args);
+        }
 
     }
 


### PR DESCRIPTION
Hi, what do you think about prevent dispatching ping event to store? I think it can save bunch of work for those who has many actions and mutations in vuex store. maybe there is a sense to add an option for this?